### PR TITLE
Get screenshot working on Linux; case name & timestamp in default filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# npm install likes to mess with this, also it's huge
+node_modules

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
     <div class="container window align-content-center">
         <h1>DocumentIt</h1>
         <form>
-            <input type="text" name="casename" placeholder="Case Name"><br>
-            <input type="text" name="socialmedia" placeholder="Social Media"><br>
-            <textarea name="description" placeholder="Incident Description..." rows="10" cols="30"></textarea>
+            <input type="text" id="casename" name="casename" placeholder="Case Name"><br>
+            <input type="text" id="socialmedia" name="socialmedia" placeholder="Social Media"><br>
+            <textarea id="description" name="description" placeholder="Incident Description..." rows="10" cols="30"></textarea>
         </form>
 
         <label id="screenshot-path">Path:</label><br>

--- a/renderer.js
+++ b/renderer.js
@@ -12,8 +12,10 @@ const path = require('path');
 const screenshot = document.getElementById('screen-shot');
 const screenshotMsg = document.getElementById('screenshot-path');
 const pathButton = document.getElementById('path-button');
+const casenameField = document.getElementById('casename');
 
 var screenshotPath = '';
+var caseName = '';
 
 pathButton.addEventListener('click', function(event) {
     dialog.showSaveDialog(function(fileName) {
@@ -34,10 +36,12 @@ screenshot.addEventListener('click', function(event) {
         if (error) return console.log(error.message);
 
         sources.forEach(function(source) {
-            if (source.name === 'Entire Screen' || source.name === 'Screen 1') {
+            if (source.name === 'Entire Screen' || source.name === 'Entire screen' || source.name === 'Screen 1') {
 
+                caseName = casenameField.value;
                 if (screenshotPath === '') {
-                    screenshotPath = path.join(os.tmpdir(), 'screenshot.png');
+                    timestamp = new Date().getTime();
+                    screenshotPath = path.join(os.tmpdir(), caseName+'-'+timestamp+'.png');
                 }
 
                 fs.writeFile(screenshotPath, source.thumbnail.toPng(), function(error) {


### PR DESCRIPTION
Your previous commit implied screenshots weren't working but with a minor change it worked for me! I'd like to contribute so I worked towards your issue #2 and grabbed the case name and a number (timestamp, not sure how you wanted to handle unique integers) for the filename when none is specified. I also added a .gitignore for node_modules because electron on my system seems to run differently than on yours. Maybe I'm not doing something right but ignoring that folder seems common.

If you'd prefer I didn't contribute, or contribute in some other way, just let me know. Cheers and good luck!
  