### PR TITLE
Task 1a is done, but a path should be required, and the path should be a folder not a file

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
             <textarea id="description" name="description" placeholder="Incident Description..." rows="10" cols="30"></textarea>
         </form>
 
-        <label id="screenshot-path">Path:</label><br>
+        <label id="screenshot-path">Path: NONE</label><br>
         <button id="path-button" class="btn btn-primary">Select Path</button><br>
         <button id="screen-shot" class="btn btn-primary">Take Screenshot</button>
     </div>


### PR DESCRIPTION
We can mark 1a done in Projects:

(1) Users can save a screenshot.
a) Directly with the app

However I think the user should be required to select a path before saving because most people have no idea how to find the /tmp folder and would be upset when the /tmp folder is deleted upon reboot.

Finally, if you currently save multiple screenshots to a path it will overwrite the file instead of creating a new file. So we should auto-name files and have the user select a path folder only.

This PR fixes both of the above.